### PR TITLE
Fix build error

### DIFF
--- a/php_serializer.gemspec
+++ b/php_serializer.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-	s.extensions = %w[ext/php_serializer/extconf.rb]
+  spec.extensions = %w[ext/php_serializer/extconf.rb]
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.15"


### PR DESCRIPTION
Fixes simple typo in gemfile that prevents the gem from building with this error:

```
$ gem build php_serializer.gemspec 
Invalid gemspec in [php_serializer.gemspec]: undefined local variable or method `s' for Gem::Specification:Class
ERROR:  Error loading gemspec. Aborting.
```
