### PR TITLE
Fix missing space in README by rearranging paragraph.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # PhpSerializer
 
-Native PHP serializer and unserializer(Note: currently only supports PHP primitive data-types) for Ruby and it is heavily inspired by PHP source code.
+Native PHP serializer and unserializer for Ruby.  It is heavily
+inspired by PHP source code.
+
+Note: Currently only supports PHP primitive data-types.
 
 ## Installation
 


### PR DESCRIPTION
Fix missing space in README by rearranging paragraph.

This is a bit of a heavy-handed fix--the missing space in "unserializer(Note" doesn't need the entire paragraph to be rewritten.  However, I think the paragraph reads a little better this way so wanted to suggest it.
